### PR TITLE
Add go documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Megaphone Golang client
 =======================
 
+[![GoDoc](https://godoc.org/github.com/redbubble/megaphone-client-golang/megaphone?status.svg)](https://godoc.org/github.com/redbubble/megaphone-client-golang/megaphone)
+[![Go Report Card](https://goreportcard.com/badge/github.com/redbubble/megaphone-client-golang/megaphone)](https://goreportcard.com/report/github.com/redbubble/megaphone-client-golang/megaphone)
 [![Build status](https://badge.buildkite.com/8d56deb25d44956e5628dcae206230d344dbb16ca1798f7bd9.svg?branch=master)](https://buildkite.com/redbubble/megaphone-client-golang)
 
 Send events to [Megaphone][megaphone] from [Golang][golang] applications.

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Install the package:
 
 ```bash
 # Using Go get:
-go get github.com/redbubble/megaphone-client-golang
+go get github.com/redbubble/megaphone-client-golang/megaphone
 
 # Using govendor:
-govendor fetch github.com/redbubble/megaphone-client-golang@v1
+govendor fetch github.com/redbubble/megaphone-client-golang/megaphone@v1
 ```
 
 Usage

--- a/megaphone/client.go
+++ b/megaphone/client.go
@@ -1,3 +1,5 @@
+// Package megaphone provides a client for Megaphone, Redbubble's event
+// broadcasting system for inter-service communication.
 package megaphone
 
 import (
@@ -7,17 +9,23 @@ import (
 	"github.com/redbubble/megaphone-client-golang/megaphone/logger"
 )
 
+// Config holds the configuration for a Client.
 type Config struct {
 	Origin string
 	Host   string
 	Port   int
 }
 
+// Client provides a standard interface to publish events to Megaphone.
+// Conventionally, a FileLogger is used if no configuration for
+// a FluentLogger is provided, allowing for easy local development
+// in absence of a local Megaphone Fluentd container.
 type Client struct {
 	config Config
 	logger logger.Logger
 }
 
+// NewClient returns a configured Megaphone Client.
 func NewClient(config Config) (client *Client, err error) {
 	client = &Client{}
 	client.config = config
@@ -42,6 +50,7 @@ func NewClient(config Config) (client *Client, err error) {
 	return
 }
 
+// Publish sends an event to Megaphone, or to a local file depending on the Client configuration.
 func (c *Client) Publish(origin, topic, subtopic, schema, partitionKey string, payload []byte) (err error) {
 	event, err := newEvent(origin, topic, subtopic, schema, partitionKey, payload)
 	if err != nil {

--- a/megaphone/errors.go
+++ b/megaphone/errors.go
@@ -2,6 +2,7 @@ package megaphone
 
 import "fmt"
 
+// PublicationError is returned when an event couldn't be published.
 type PublicationError struct {
 	e     error
 	event string
@@ -11,6 +12,7 @@ func (pe *PublicationError) Error() string {
 	return fmt.Sprintf("The following event couldn't be published: error: %s, event: %v", pe.e, pe.event)
 }
 
+// NewPublicationError return a PublicationError for a given event.
 func NewPublicationError(e error, event string) *PublicationError {
 	return &PublicationError{
 		e:     e,
@@ -18,6 +20,7 @@ func NewPublicationError(e error, event string) *PublicationError {
 	}
 }
 
+// ConfigError is returned when the configuration provided for a Client is invalid.
 type ConfigError struct {
 	e     error
 	field string
@@ -30,6 +33,7 @@ func (ce *ConfigError) Error() string {
 	return fmt.Sprintf("The configuration of the megaphone client is not valid: field: %s, error: %s", ce.field, ce.e)
 }
 
+// NewConfigErrorWithField returns a ConfigError with details about the invalid Config field.
 func NewConfigErrorWithField(e error, field string) *ConfigError {
 	return &ConfigError{
 		e:     e,
@@ -37,12 +41,14 @@ func NewConfigErrorWithField(e error, field string) *ConfigError {
 	}
 }
 
+// NewConfigError returns a general ConfigError.
 func NewConfigError(e error) *ConfigError {
 	return &ConfigError{
 		e: e,
 	}
 }
 
+// PayloadError is returned when the event payload to be published is invalid.
 type PayloadError struct {
 	e       error
 	payload string
@@ -52,6 +58,7 @@ func (pe *PayloadError) Error() string {
 	return fmt.Sprintf("Cannot publish the message, invalid payload: error: %s, event: %v", pe.e, pe.payload)
 }
 
+// NewPayloadError returns a PayloadError for a given event payload.
 func NewPayloadError(e error, payload string) *PayloadError {
 	return &PayloadError{
 		e:       e,

--- a/megaphone/logger/filelogger.go
+++ b/megaphone/logger/filelogger.go
@@ -10,7 +10,7 @@ type fileLogger struct {
 
 // NewFileLogger returns a configured file logger to publish events to a local file,
 // mainly for development purposes.
-func NewFileLogger() (*fileLogger, error) {
+func NewFileLogger() (Logger, error) {
 	return &fileLogger{}, nil
 }
 

--- a/megaphone/logger/filelogger.go
+++ b/megaphone/logger/filelogger.go
@@ -8,6 +8,8 @@ import (
 type fileLogger struct {
 }
 
+// NewFileLogger returns a configured file logger to publish events to a local file,
+// mainly for development purposes.
 func NewFileLogger() (*fileLogger, error) {
 	return &fileLogger{}, nil
 }

--- a/megaphone/logger/fluentlogger.go
+++ b/megaphone/logger/fluentlogger.go
@@ -11,6 +11,8 @@ type fluentLogger struct {
 	Fluent *fluent.Fluent
 }
 
+// NewFluentLogger returns a Logger that can publish events to Megaphone
+// via a Megaphone Fluentd container.
 func NewFluentLogger(fluentHost string, fluentPort int) (logger *fluentLogger, err error) {
 	logger = &fluentLogger{}
 	logger.Fluent, err = fluent.New(fluent.Config{

--- a/megaphone/logger/fluentlogger.go
+++ b/megaphone/logger/fluentlogger.go
@@ -2,7 +2,6 @@ package logger
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/fluent/fluent-logger-golang/fluent"
 )
@@ -13,18 +12,17 @@ type fluentLogger struct {
 
 // NewFluentLogger returns a Logger that can publish events to Megaphone
 // via a Megaphone Fluentd container.
-func NewFluentLogger(fluentHost string, fluentPort int) (logger *fluentLogger, err error) {
-	logger = &fluentLogger{}
-	logger.Fluent, err = fluent.New(fluent.Config{
+func NewFluentLogger(fluentHost string, fluentPort int) (logger Logger, err error) {
+	fluentLogger := &fluentLogger{}
+	fluentLogger.Fluent, err = fluent.New(fluent.Config{
 		FluentHost: fluentHost,
 		FluentPort: fluentPort,
 	})
-
 	if err != nil {
-		fmt.Println(err)
 		return
 	}
 
+	logger = fluentLogger
 	return
 }
 

--- a/megaphone/logger/logger.go
+++ b/megaphone/logger/logger.go
@@ -1,9 +1,16 @@
+// Package logger provides a logger that the Megaphone client
+// can use to publish to a local file or to Megaphone via Fluentd.
 package logger
 
+// Logger is a generic mecanism for megaphone.Client to post events.
 type Logger interface {
 	Post(topic string, message interface{}) error
 }
 
+// NewLogger returns a new Logger to be used by a megaphone.Client.
+// Conventionally, a FileLogger is returned if no configuration for
+// a FluentLogger is provided, allowing for easy local development
+// in absence of a local Megaphone Fluentd container.
 func NewLogger(host string, port int) (Logger, error) {
 	if host != "" && port > 0 {
 		fluentLogger, err := NewFluentLogger(host, port)


### PR DESCRIPTION
**When I** maintain an open-source client for Megaphone 
**I want** its documentation to be available on GoDoc 
**And** its code to follow the community conventions 
**So that** is feels familiar and accessible to anyone interested in it 

See https://trello.com/c/4zwPp3LF/868-refine-the-golang-megaphone-client-api