### PR TITLE
Make client an interface so it could be mocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and
 this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 0.1.0 - 2017-12-28
+## Unreleased - 2017-11-29
+
+### Changed
+
+- Make `megaphone.Client` an interface so it could be mocked (e.g. using [pegomocks](https://github.com/petergtz/pegomock))
+- Change the `megaphone.Client` constructor to require the origin, host and port directly instead of requiring a `megaphone.Config` structure
+
+## 0.1.0 - 2017-11-28
 
 ### Added
 

--- a/megaphone/client.go
+++ b/megaphone/client.go
@@ -51,8 +51,10 @@ func NewClient(config Config) (client *Client, err error) {
 }
 
 // Publish sends an event to Megaphone, or to a local file depending on the Client configuration.
-func (c *Client) Publish(origin, topic, subtopic, schema, partitionKey string, payload []byte) (err error) {
-	event, err := newEvent(origin, topic, subtopic, schema, partitionKey, payload)
+func (c *Client) Publish(topic, subtopic, schema, partitionKey string, payload []byte) (err error) {
+	event, err := newEvent(topic, subtopic, schema, partitionKey, payload)
+	event.Origin = c.config.Origin
+
 	if err != nil {
 		return NewPayloadError(err, string(payload))
 	}

--- a/megaphone/client_test.go
+++ b/megaphone/client_test.go
@@ -17,25 +17,20 @@ func TestClient(t *testing.T) {
 			Port:   24224,
 		}
 	}
-
-	t.Run("NewClient()", func(t *testing.T) {
+	t.Run("newConfig()", func(t *testing.T) {
 		t.Run("Host defaults to MEGAPHONE_FLUENT_HOST", func(t *testing.T) {
-			config := getConfig()
-			config.Host = ""
 			expectedHost := "localhost"
 			os.Setenv("MEGAPHONE_FLUENT_HOST", expectedHost)
-			client, err := NewClient(config)
+			config, err := newConfig("my-awesome-service", "", 24224)
 			require.Nil(t, err)
-			assert.Equal(t, expectedHost, client.config.Host)
+			assert.Equal(t, expectedHost, config.Host)
 			os.Unsetenv("MEGAPHONE_FLUENT_HOST")
 		})
 
 		t.Run("It fails when the port set by the user is not an valid number", func(t *testing.T) {
-			config := getConfig()
 			os.Setenv("MEGAPHONE_FLUENT_PORT", "not a valid port")
-			_, err := NewClient(config)
-			_, ok := err.(*ConfigError)
-			assert.Equal(t, true, ok)
+			_, err := newConfig("my-awesome-service", "", 0)
+			require.NotNil(t, err)
 			os.Unsetenv("MEGAPHONE_FLUENT_PORT")
 		})
 	})
@@ -64,7 +59,7 @@ func TestClient(t *testing.T) {
 
 		t.Run("It publishes a message through the fluent logger", func(t *testing.T) {
 			config := getConfig()
-			client, err := NewClient(config)
+			client, err := NewClient(config.Origin, config.Host, config.Port)
 			require.Nil(t, err)
 
 			eventFields := GetTestEventFields()
@@ -75,7 +70,7 @@ func TestClient(t *testing.T) {
 		t.Run("It publishes a message through the file logger", func(t *testing.T) {
 			config := getConfig()
 			config.Port = 0
-			client, err := NewClient(config)
+			client, err := NewClient(config.Origin, config.Host, config.Port)
 			require.Nil(t, err)
 
 			eventFields := GetTestEventFields()
@@ -85,7 +80,7 @@ func TestClient(t *testing.T) {
 
 		t.Run("It returns a new payload error", func(t *testing.T) {
 			config := getConfig()
-			client, err := NewClient(config)
+			client, err := NewClient(config.Origin, config.Host, config.Port)
 			require.Nil(t, err)
 
 			eventFields := GetTestEventFields()

--- a/megaphone/client_test.go
+++ b/megaphone/client_test.go
@@ -68,7 +68,7 @@ func TestClient(t *testing.T) {
 			require.Nil(t, err)
 
 			eventFields := GetTestEventFields()
-			err = client.Publish(eventFields.Origin, eventFields.Topic, eventFields.Subtopic, eventFields.Schema, eventFields.PartitionKey, eventFields.Payload)
+			err = client.Publish(eventFields.Topic, eventFields.Subtopic, eventFields.Schema, eventFields.PartitionKey, eventFields.Payload)
 			require.Nil(t, err)
 		})
 
@@ -79,7 +79,7 @@ func TestClient(t *testing.T) {
 			require.Nil(t, err)
 
 			eventFields := GetTestEventFields()
-			err = client.Publish(eventFields.Origin, eventFields.Topic, eventFields.Subtopic, eventFields.Schema, eventFields.PartitionKey, eventFields.Payload)
+			err = client.Publish(eventFields.Topic, eventFields.Subtopic, eventFields.Schema, eventFields.PartitionKey, eventFields.Payload)
 			require.Nil(t, err)
 		})
 
@@ -90,7 +90,7 @@ func TestClient(t *testing.T) {
 
 			eventFields := GetTestEventFields()
 			eventFields.Payload = []byte("{\"url\" \"https://www.redbubble.com/people/wytrab8/works/26039653-toadally-rad\"}")
-			err = client.Publish(eventFields.Origin, eventFields.Topic, eventFields.Subtopic, eventFields.Schema, eventFields.PartitionKey, eventFields.Payload)
+			err = client.Publish(eventFields.Topic, eventFields.Subtopic, eventFields.Schema, eventFields.PartitionKey, eventFields.Payload)
 			_, ok := err.(*PayloadError)
 			assert.Equal(t, true, ok)
 		})

--- a/megaphone/event.go
+++ b/megaphone/event.go
@@ -13,7 +13,7 @@ type event struct {
 	Payload      map[string]interface{} `json:"data"`
 }
 
-func newEvent(origin, topic, subtopic, schema, partitionKey string, payload []byte) (*event, error) {
+func newEvent(topic, subtopic, schema, partitionKey string, payload []byte) (*event, error) {
 	var mapPayload map[string]interface{}
 	err := json.Unmarshal([]byte(payload), &mapPayload)
 	if err != nil {
@@ -21,7 +21,6 @@ func newEvent(origin, topic, subtopic, schema, partitionKey string, payload []by
 	}
 
 	return &event{
-		Origin:       origin,
 		Topic:        topic,
 		Subtopic:     subtopic,
 		Schema:       schema,

--- a/megaphone/event_test.go
+++ b/megaphone/event_test.go
@@ -17,7 +17,8 @@ func TestEvent(t *testing.T) {
 		partitionKey := "1357924680"
 		payload := []byte("{\"url\": \"https://www.redbubble.com/people/wytrab8/works/26039653-toadally-rad\"}")
 
-		actualEvent, err := newEvent(origin, topic, subtopic, schema, partitionKey, payload)
+		actualEvent, err := newEvent(topic, subtopic, schema, partitionKey, payload)
+		actualEvent.Origin = origin
 		assert.Nil(t, err)
 		json, err := actualEvent.toJSON()
 		assert.Nil(t, err)


### PR DESCRIPTION
**When I** use the megaphone client 
**I want** to be able to generate mocks for it
**So that** I can test my code without having to use the actual implementation

Follow-up on https://github.com/redbubble/megaphone-client-golang/pull/2