### PR TITLE
 Move the build pipeline to Travis CI

### DIFF
--- a/.buildkite/megaphone-client-golang.yml
+++ b/.buildkite/megaphone-client-golang.yml
@@ -1,7 +1,0 @@
-steps:
-  - name: 'unit test'
-    env:
-      BUILD_ARGS: "tests"
-    command: scripts/build.sh
-    agents:
-      location: aws

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+> Thank you for you pull request!
+>
+> (Please write a [job story](https://robots.thoughtbot.com/converting-to-jobs-stories) to explain why you want this change, as a user, maintainer, whatever makes sense.)
+
+**When I** ...
+**I want to** ...
+**So that** ...
+
+> Then make sure that you provide enough information in this pull request for it to be reviewed:
+
+I didn't forget to:
+
+* [ ] update the `README`
+* [ ] add [specs](../spec) for the changes I made
+* [ ] update the `CHANGELOG`, describing the relevant changes as [**Unreleased**](https://keepachangelog.com)
+* [ ] evaluate the impact of this change to the Megaphone client API (other clients do implement the API)
+* [ ] get in touch with other Megaphone clients maintainers to coordinate relevant updates
+
+> Eventually, mention any relevant Trello card, [issue](https://help.github.com/articles/closing-issues-using-keywords/), other PR or reference.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: required
+
+
+language: go
+go:
+  - 1.9
+  - master
+services:
+  - docker
+script: make tests

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ unit-test: ## Run the unit test suite
 		--network megaphone-network \
 		-e MEGAPHONE_FLUENT_HOST="fluent-container" \
 		--volume ${PWD}:/go/src/github.com/redbubble/megaphone-client-golang \
-		-it redbubble/debian-golang-1.9:master /bin/sh -c 'cd /go/src/github.com/redbubble/megaphone-client-golang && go test -v -p 1 -cover `go list ./...`'
+		-it golang:1.9-alpine /bin/sh -c 'cd /go/src/github.com/redbubble/megaphone-client-golang && go test -v -p 1 -cover `go list ./...`'
 
 create-fluent-container: ## Create and start the fluent container needed for the tests
 	@echo "--- Creating the fluent container"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![GoDoc](https://godoc.org/github.com/redbubble/megaphone-client-golang/megaphone?status.svg)](https://godoc.org/github.com/redbubble/megaphone-client-golang/megaphone)
 [![Go Report Card](https://goreportcard.com/badge/github.com/redbubble/megaphone-client-golang/megaphone)](https://goreportcard.com/report/github.com/redbubble/megaphone-client-golang/megaphone)
-[![Build status](https://badge.buildkite.com/8d56deb25d44956e5628dcae206230d344dbb16ca1798f7bd9.svg?branch=master)](https://buildkite.com/redbubble/megaphone-client-golang)
 [![Build Status](https://travis-ci.org/redbubble/megaphone-client-golang.svg?branch=master)](https://travis-ci.org/redbubble/megaphone-client-golang)
 
 Send events to [Megaphone][megaphone] from [Golang][golang] applications.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Megaphone Golang client
-=======================
+# Megaphone Golang client
 
 [![GoDoc](https://godoc.org/github.com/redbubble/megaphone-client-golang/megaphone?status.svg)](https://godoc.org/github.com/redbubble/megaphone-client-golang/megaphone)
 [![Go Report Card](https://goreportcard.com/badge/github.com/redbubble/megaphone-client-golang/megaphone)](https://goreportcard.com/report/github.com/redbubble/megaphone-client-golang/megaphone)
@@ -7,11 +6,10 @@ Megaphone Golang client
 
 Send events to [Megaphone][megaphone] from [Golang][golang] applications.
 
-  [megaphone]: https://github.com/redbubble/megaphone
-  [golang]: https://golang.org/
+[megaphone]: https://github.com/redbubble/megaphone
+[golang]: https://golang.org/
 
-Getting Started
----------------
+## Getting Started
 
 Install the package:
 
@@ -23,18 +21,17 @@ go get github.com/redbubble/megaphone-client-golang/megaphone
 govendor fetch github.com/redbubble/megaphone-client-golang/megaphone@v1
 ```
 
-Usage
------
+## Usage
 
 In order to be as unobstrusive as possible, this client will append events to local files (e.g. `./work-updates.stream`) unless:
 
-- the `MEGAPHONE_FLUENT_HOST` and `MEGAPHONE_FLUENT_PORT` environment variables are set.
-- **or** the Fluentd host and port values are passed as arguments to the client's constructor
+* the `MEGAPHONE_FLUENT_HOST` and `MEGAPHONE_FLUENT_PORT` environment variables are set.
+* **or** the Fluentd host and port values are passed as arguments to the client's constructor
 
 That behaviour ensures that unless you want to send events to the Megaphone [streams][stream], you do not need to [start Fluentd][megaphone-fluentd] at all.
 
-  [stream]: https://github.com/redbubble/com/megaphone#stream
-  [megaphone-fluentd]: https://github.com/redbubble/megaphone-fluentd-container
+[stream]: https://github.com/redbubble/com/megaphone#stream
+[megaphone-fluentd]: https://github.com/redbubble/megaphone-fluentd-container
 
 ### Publishing events
 
@@ -64,17 +61,15 @@ if err != nil {
 }
 ```
 
-Credits
--------
+## Credits
 
 [![](doc/redbubble.png)][redbubble]
 
 This Megaphone Golang client is maintained and funded by [Redbubble][redbubble].
 
-  [redbubble]: https://www.redbubble.com
+[redbubble]: https://www.redbubble.com
 
-License
--------
+## License
 
     megaphone
     Copyright (C) 2017 Redbubble

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![GoDoc](https://godoc.org/github.com/redbubble/megaphone-client-golang/megaphone?status.svg)](https://godoc.org/github.com/redbubble/megaphone-client-golang/megaphone)
 [![Go Report Card](https://goreportcard.com/badge/github.com/redbubble/megaphone-client-golang/megaphone)](https://goreportcard.com/report/github.com/redbubble/megaphone-client-golang/megaphone)
 [![Build status](https://badge.buildkite.com/8d56deb25d44956e5628dcae206230d344dbb16ca1798f7bd9.svg?branch=master)](https://buildkite.com/redbubble/megaphone-client-golang)
+[![Build Status](https://travis-ci.org/redbubble/megaphone-client-golang.svg?branch=master)](https://travis-ci.org/redbubble/megaphone-client-golang)
 
 Send events to [Megaphone][megaphone] from [Golang][golang] applications.
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-TARGETS=$BUILD_ARGS
-make $TARGETS
-EXIT_CODE=$?
-exit $EXIT_CODE


### PR DESCRIPTION
**When I** run a build pipeline on PR creation 
**I want** that build to run on Travis CI 
**So that** the person who opened the PR can actually follow up on the build 

**Context**: Our Buildkite pipelines are not public.

I didn't forget to:

* [x] update the `README`
* [ ] ~add tests for the changes I made~
* [ ] ~update the `CHANGELOG`, describing the relevant changes as [**Unreleased**](https://keepachangelog.com)~
* [x] evaluate the impact of this change to the Megaphone client API (other clients do implement the API)
* [ ] ~get in touch with other Megaphone clients maintainers to coordinate relevant updates~

See https://trello.com/c/RhmuGaKB/1038 (private)
See also https://github.com/redbubble/megaphone-client-ruby/issues/23