### PR TITLE
allow publishing raw messages to a kinesis stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and
 this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.1.0 - 2018-11-15
+
+### Added
+
+- Add `PublishRawMessage` method to all the client to publish raw messages to a Kinesis stream. 
+
+
 ## 1.0.0 - 2018-03-09
 
 ### Changed

--- a/megaphone/fluentdclient.go
+++ b/megaphone/fluentdclient.go
@@ -3,6 +3,7 @@
 package megaphone
 
 import (
+	"errors"
 	"os"
 	"strconv"
 
@@ -86,4 +87,8 @@ func (c *FluentdClient) Publish(topic, subtopic, schema, partitionKey string, pa
 		return NewPublicationError(err, eventJSON)
 	}
 	return nil
+}
+
+func (c *FluentdClient) PublishRawMessage(streamName string, partitionKey string, messageBytes []byte) error {
+	return errors.New("The method has not been implemented")
 }

--- a/megaphone/fluentdclient_test.go
+++ b/megaphone/fluentdclient_test.go
@@ -90,5 +90,14 @@ func TestClient(t *testing.T) {
 			assert.Equal(t, true, ok)
 		})
 	})
+	
+	t.Run("PublishRawMessage()", func(t *testing.T) {
+		required := require.New(t)
+		config := getConfig()
+		client, err := NewFluentdClient(config.Origin, config.Host, config.Port)
+
+		err = client.PublishRawMessage("streamName", "partitionKey", nil)
+		required.Error(err)
+	})
 
 }

--- a/megaphone/kinesissynchronouspublisher.go
+++ b/megaphone/kinesissynchronouspublisher.go
@@ -1,7 +1,6 @@
 package megaphone
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/kinesis"
 	"github.com/aws/aws-sdk-go/service/kinesis/kinesisiface"
 	"github.com/redbubble/megaphone-client-golang/megaphone/kinesisclient"
@@ -33,18 +32,14 @@ func (c *KinesisSynchronousPublisher) Publish(topic, subtopic, schema, partition
 	if err != nil {
 		return err
 	}
-	err = c.PublishRawMessage(event.streamName(c.config.DeployEnv), partitionKey, bytes)
-	if err != nil {
-		return err
-	}
-	return nil
+	return c.PublishRawMessage(event.streamName(c.config.DeployEnv), partitionKey, bytes)
 }
 
 func (c *KinesisSynchronousPublisher) PublishRawMessage(streamName string, partitionKey string, messageBytes []byte) error {
 	input := &kinesis.PutRecordInput{
 		Data:         messageBytes,
 		PartitionKey: &partitionKey,
-		StreamName:   aws.String(streamName),
+		StreamName:   &streamName,
 	}
 	err := input.Validate()
 	if err != nil {

--- a/megaphone/kinesissynchronouspublisher.go
+++ b/megaphone/kinesissynchronouspublisher.go
@@ -1,8 +1,8 @@
 package megaphone
 
 import (
-	"github.com/aws/aws-sdk-go/service/kinesis"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/kinesis"
 	"github.com/aws/aws-sdk-go/service/kinesis/kinesisiface"
 	"github.com/redbubble/megaphone-client-golang/megaphone/kinesisclient"
 )
@@ -33,12 +33,20 @@ func (c *KinesisSynchronousPublisher) Publish(topic, subtopic, schema, partition
 	if err != nil {
 		return err
 	}
-	input := &kinesis.PutRecordInput{
-		Data:         bytes,
-		PartitionKey: &partitionKey,
-		StreamName:   aws.String(event.streamName(c.config.DeployEnv)),
+	err = c.PublishRawMessage(event.streamName(c.config.DeployEnv), partitionKey, bytes)
+	if err != nil {
+		return err
 	}
-	err = input.Validate()
+	return nil
+}
+
+func (c *KinesisSynchronousPublisher) PublishRawMessage(streamName string, partitionKey string, messageBytes []byte) error {
+	input := &kinesis.PutRecordInput{
+		Data:         messageBytes,
+		PartitionKey: &partitionKey,
+		StreamName:   aws.String(streamName),
+	}
+	err := input.Validate()
 	if err != nil {
 		return err
 	}

--- a/megaphone/publisher.go
+++ b/megaphone/publisher.go
@@ -3,4 +3,5 @@ package megaphone
 // Publisher provides means to publish an event.
 type Publisher interface {
 	Publish(topic, subtopic, schema, partitionKey string, payload []byte) (err error)
+	PublishRawMessage(streamName string, partitionKey string, messageBytes []byte) (err error)
 }


### PR DESCRIPTION
This PR is for allowing megaphone to publish a raw message to any Kinesis stream.

I didn't forget to:

* [x] update the `README`
* [x] add [specs](../spec) for the changes I made
* [x] update the `CHANGELOG`, describing the relevant changes as [**Unreleased**](https://keepachangelog.com)
* [x] evaluate the impact of this change to the Megaphone client API (other clients do implement the API)
* [x] get in touch with other Megaphone clients maintainers to coordinate relevant updates

|[Trello](https://trello.com/c/DMazA8nI/288-18-provide-data-sf-with-property-data-along-with-licensing-data)|
|--|
