### PR TITLE
Pass the AWS Session as a dependency to the kinesis client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and
 this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 2.0.0 - 2019-09-20
+
+### Changed
+
+Pass the AWS Session as a dependency to the kinesis client
+
 ## 1.2.0 - 2019-09-20
 
 ### Changed

--- a/megaphone/kinesisclient/provider.go
+++ b/megaphone/kinesisclient/provider.go
@@ -11,11 +11,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/kinesis"
 )
 
-func Provide(config Config) (*kinesis.Kinesis, error) {
+func Provide(sess *session.Session, config Config) (*kinesis.Kinesis, error) {
 	if config.HostedOnAWS {
-		sess := session.Must(session.NewSession(&aws.Config{
-			LogLevel: aws.LogLevel(aws.LogOff),
-		}))
 		region, regionErr := ec2metadata.New(sess).Region()
 		if regionErr != nil {
 			return nil, regionErr
@@ -23,9 +20,6 @@ func Provide(config Config) (*kinesis.Kinesis, error) {
 		creds := ec2rolecreds.NewCredentials(sess)
 		return kinesis.New(sess, aws.NewConfig().WithCredentials(creds).WithRegion(region)), nil
 	} else {
-		sess := session.Must(session.NewSession(&aws.Config{
-			LogLevel: aws.LogLevel(aws.LogOff),
-		}))
 		return kinesis.New(sess, aws.NewConfig().
 			WithEndpoint(os.Getenv("MEGAPHONE_KINESIS_TEST_ENDPOINT")).
 			WithDisableSSL(true).

--- a/megaphone/kinesissynchronouspublisher.go
+++ b/megaphone/kinesissynchronouspublisher.go
@@ -1,6 +1,7 @@
 package megaphone
 
 import (
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kinesis"
 	"github.com/aws/aws-sdk-go/service/kinesis/kinesisiface"
 	"github.com/redbubble/megaphone-client-golang/megaphone/kinesisclient"
@@ -11,8 +12,8 @@ type KinesisSynchronousPublisher struct {
 	config        kinesisclient.Config
 }
 
-func NewKinesisSynchronousPublisher(config kinesisclient.Config) (*KinesisSynchronousPublisher, error) {
-	client, err := kinesisclient.Provide(config)
+func NewKinesisSynchronousPublisher(sess *session.Session, config kinesisclient.Config) (*KinesisSynchronousPublisher, error) {
+	client, err := kinesisclient.Provide(sess, config)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This allows the user of the library to trace the kinesis requests through the AWS Session

> Then make sure that you provide enough information in this pull request for it to be reviewed:

I didn't forget to:

* [ ] update the `README`
* [ ] add [specs](../spec) for the changes I made
* [x] update the `CHANGELOG`, describing the relevant changes as [**Unreleased**](https://keepachangelog.com)
* [ ] evaluate the impact of this change to the Megaphone client API (other clients do implement the API)
* [ ] get in touch with other Megaphone clients maintainers to coordinate relevant updates

> Eventually, mention any relevant Trello card, [issue](https://help.github.com/articles/closing-issues-using-keywords/), other PR or reference.
